### PR TITLE
Loosen pragma Solidity version specification

### DIFF
--- a/differential_testing/test/DifferentialTests.t.sol
+++ b/differential_testing/test/DifferentialTests.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "../../src/Merkle.sol";
 import "forge-std/Test.sol";

--- a/differential_testing/test/utils/Strings2.sol
+++ b/differential_testing/test/utils/Strings2.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 library Strings2 {
 

--- a/src/Merkle.sol
+++ b/src/Merkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "./common/MurkyBase.sol";
 

--- a/src/Xorkle.sol
+++ b/src/Xorkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "./common/MurkyBase.sol";
 

--- a/src/common/MurkyBase.sol
+++ b/src/common/MurkyBase.sol
@@ -1,5 +1,5 @@
 // LICENSE IDENTIFIER: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 abstract contract MurkyBase {
     /***************

--- a/src/test/Merkle.t.sol
+++ b/src/test/Merkle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "../Merkle.sol";
 import "forge-std/Test.sol";

--- a/src/test/MurkyBase.t.sol
+++ b/src/test/MurkyBase.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "forge-std/Test.sol";
 import "../common/MurkyBase.sol";

--- a/src/test/StandardInput.t.sol
+++ b/src/test/StandardInput.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "../Xorkle.sol";
 import "../Merkle.sol";

--- a/src/test/Xorkle.t.sol
+++ b/src/test/Xorkle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.13;
+pragma solidity ^0.8.4;
 
 import "../Xorkle.sol";
 import "forge-std/Test.sol";


### PR DESCRIPTION
Currently limiting us from building Seaport with 0.8.14 when testing with Forge
Chose 0.8.4 since that's when safemath was introduced, and still see a lot of contracts that specify it, no specific reason other than that